### PR TITLE
Define molecules without input files #11

### DIFF
--- a/src/BasisSets.jl
+++ b/src/BasisSets.jl
@@ -20,6 +20,7 @@ module BasisSets
         getatom,
         Molecule,
         molecule,
+        @molecule,
         getatoms,
         doublefactorial,
         normalization,

--- a/src/molecule.jl
+++ b/src/molecule.jl
@@ -72,7 +72,7 @@ function parse_xyz(xyztext::String)::Molecule
     coordinates = []
     Zvalues = []
     for line in eachline(IOBuffer(xyztext))
-        m = match(r"(?<symbol>[a-zA-Z]+)\s+(?<x>[+-]?\d+(?:\.\d+)?)\s+(?<y>[+-]?\d+(?:\.\d+)?)\s+(?<z>[+-]?\d+(?:\.\d+)?)", line)
+        m = match(r"(?<symbol>[a-zA-Z]+)\s+(?<x>[+-]?\d+(?:\.\d+)?)\s+(?<y>[+-]?\d+(?:\.\d+)?)\s+(?<z>[+-]?\d+(?:\.\d+)?)[\s\t\n]*$", line)
         if startswith(line, r"^[\s\t]*#")
             @info "The line \"$line\" is a comment and will be skipped."
         elseif line=="" || isempty(line) || occursin(r"^[\s\t]*$", line)

--- a/src/molecule.jl
+++ b/src/molecule.jl
@@ -106,6 +106,6 @@ macro molecule(block)
     mol = string(block)
     mol = replace(mol, "{" => "\"")
     mol = replace(mol, "}" => "\"")
-    mol = eval(Meta.parse(mol))
+    mol = esc(Meta.parse(mol))
     :(parse_xyz($mol))
 end

--- a/src/molecule.jl
+++ b/src/molecule.jl
@@ -85,7 +85,7 @@ function parse_xyz(xyztext::String)::Molecule
             push!(coordinates, coordinate)
             push!(Zvalues, Zvalue)
         else
-            throw("The line \"$line\" does not match expected format.")
+            throw(ErrorException("The line \"$line\" does not match expected format."))
         end
     end
     coordinates = mapreduce(permutedims, vcat, coordinates)

--- a/src/molecule.jl
+++ b/src/molecule.jl
@@ -73,9 +73,9 @@ function parse_xyz(xyztext::String)::Molecule
     Zvalues = []
     for line in eachline(IOBuffer(xyztext))
         m = match(r"(?<symbol>[a-zA-Z]+)\s+(?<x>[+-]?\d+(?:\.\d+)?)\s+(?<y>[+-]?\d+(?:\.\d+)?)\s+(?<z>[+-]?\d+(?:\.\d+)?)", line)
-        if startswith(line, r"\s*#")
+        if startswith(line, r"^[\s\t]*#")
             @info "The line \"$line\" is a comment and will be skipped."
-        elseif line=="" || isempty(line)
+        elseif line=="" || isempty(line) || occursin(r"^[\s\t]*$", line)
             # skip empty lines
         elseif !isnothing(m)
             element = m[:symbol]

--- a/src/molecule.jl
+++ b/src/molecule.jl
@@ -54,3 +54,58 @@ function molecule(xyzfile::String)::Molecule
 
     return Molecule(elements, coordinates, Zvalues)
 end
+
+"""
+This method takes a string (with cartesian coordinates of atoms in a molecule) and returns a ```Molecule```. The string should be formatted as follows
+
+```julia
+BasisSets.parse_xyz("
+    H  0.0  0.0  0.0
+    H  0.0  0.0  1.4
+")
+```
+
+Each line should contain the element symbol, x-coordinate, y-coordinate, and z-coordinate, with spaces between them.
+"""
+function parse_xyz(xyztext::String)::Molecule
+    elements = []
+    coordinates = []
+    Zvalues = []
+    for m in eachmatch(r"(?<symbol>[a-zA-Z]+)\s+(?<x>[+-]?\d+(?:\.\d+)?)\s+(?<y>[+-]?\d+(?:\.\d+)?)\s+(?<z>[+-]?\d+(?:\.\d+)?)", xyztext)
+        element = m[:symbol]
+        coordinate = parse.(Float64, [m[:x], m[:y], m[:z]])
+        Zvalue = BasisSets.getatom(element)
+        push!(elements, element)
+        push!(coordinates, coordinate)
+        push!(Zvalues, Zvalue)
+    end
+    coordinates = mapreduce(permutedims, vcat, coordinates)
+    return Molecule(elements, coordinates, Zvalues)
+end
+
+
+"""
+This macro takes a string without double quotation (with cartesian coordinates of atoms in a molecule) and returns a ```Molecule```. This interface is inspired [Fermi.jl](https://github.com/FermiQC/Fermi.jl).
+
+```julia
+@molecule {
+    H  0.0  0.0  0.0
+    H  0.0  0.0  1.4
+}
+```
+
+This macro supports string interpolation and is useful for calculating potential energy surfaces (PES).
+```julia
+@molecule {
+    H  0.0  0.0  0.0
+    H  0.0  0.0  \$(1.0 + 0.4)
+}
+```
+"""
+macro molecule(block)
+    mol = string(block)
+    mol = replace(mol, "{" => "\"")
+    mol = replace(mol, "}" => "\"")
+    mol = eval(Meta.parse(mol))
+    :(parse_xyz($mol))
+end

--- a/test/molecule.jl
+++ b/test/molecule.jl
@@ -1,0 +1,23 @@
+@time @testset "molecule.jl" begin
+    # benchmark for testing
+    benchmark = Molecule(["H", "H"], [0.0 0.0 0.0; 0.0 0.0 0.74], [1, 1])
+    # test `molecule()`
+    mol1 = molecule("./data/hydrogen/h-atom.xyz")
+    # test `@molecule {}`
+    mol2 = @molecule {
+                H  0.0  0.0  0.0
+                H  0.0  0.0  0.74
+            }
+    # test `BasisSets.parse_xyz()`
+    mol3 = BasisSets.parse_xyz("
+            H  0.0  0.0  0.0
+            H  0.0  0.0  0.74
+        ")
+    # @test for all cases
+    for mol in [mol1, mol2, mol3]
+        @test mol isa Molecule
+        @test mol.atoms == benchmark.atoms
+        @test mol.coords == benchmark.coords
+        @test mol.numbers == benchmark.numbers
+    end
+end

--- a/test/molecule.jl
+++ b/test/molecule.jl
@@ -1,23 +1,32 @@
 @time @testset "molecule.jl" begin
-    # benchmark for testing
+
     benchmark = Molecule(["H", "H"], [0.0 0.0 0.0; 0.0 0.0 0.74], [1, 1])
-    # test `molecule()`
+
+    println("test `molecule()`")
     mol1 = molecule("./data/hydrogen/h-atom.xyz")
-    # test `@molecule {}`
+    @test mol1 isa Molecule
+    @test mol1.atoms == benchmark.atoms
+    @test mol1.coords == benchmark.coords
+    @test mol1.numbers == benchmark.numbers
+
+    println("test `@molecule {}`")
     mol2 = @molecule {
-                H  0.0  0.0  0.0
-                H  0.0  0.0  0.74
-            }
-    # test `BasisSets.parse_xyz()`
+            H  0.0  0.0  0.0
+            H  0.0  0.0  0.74
+        }
+    @test mol2 isa Molecule
+    @test mol2.atoms == benchmark.atoms
+    @test mol2.coords == benchmark.coords
+    @test mol2.numbers == benchmark.numbers
+
+    println("test `BasisSets.parse_xyz()`")
     mol3 = BasisSets.parse_xyz("
             H  0.0  0.0  0.0
             H  0.0  0.0  0.74
         ")
-    # @test for all cases
-    for mol in [mol1, mol2, mol3]
-        @test mol isa Molecule
-        @test mol.atoms == benchmark.atoms
-        @test mol.coords == benchmark.coords
-        @test mol.numbers == benchmark.numbers
-    end
+    @test mol3 isa Molecule
+    @test mol3.atoms == benchmark.atoms
+    @test mol3.coords == benchmark.coords
+    @test mol3.numbers == benchmark.numbers
+
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,5 +3,5 @@ using Test
 
 @testset "BasisSets.jl" begin
     include("basis.jl")
-    
+    include("molecule.jl")
 end


### PR DESCRIPTION
I implemented `@molecule` macro to define molecules without input files #11. Changes:
- added `parse_xyz()` to src/molecule.jl.
- added `@molecule` to src/molecule.jl.
- exported `@molecule` in src/BasisSets.jl.
- created test/molecule.jl and added tests.
- included test/molecule.jl in test/runtests.jl.

However, unlike the issue, I did not change `molecule()` in order to maintain compatibility with the xyz file format. The `@molecule` macro allows us to complete operation within a notebook and easily calculate potential energy curves.